### PR TITLE
Use Java version 1.8 as target for Kotlin package

### DIFF
--- a/kotlin/api/build.gradle.kts
+++ b/kotlin/api/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.google.protobuf.gradle.*
 import java.io.FileInputStream
 import java.util.Properties
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
@@ -78,6 +79,13 @@ protobuf {
 
 java {
     withSourcesJar()
+
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
 }
 
 val githubProperties = Properties()

--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -1,2 +1,2 @@
 group=com.speechly
-version=0.0.5
+version=0.0.6


### PR DESCRIPTION
### What

Use Java version 1.8 target for generating Java and Kotlin code.

### Why

To provide broader compatibility for the package.
