### PR TITLE
Add app_id as mandatory parameter in TextsRequest

### DIFF
--- a/proto/speechly/slu/v1/wlu.proto
+++ b/proto/speechly/slu/v1/wlu.proto
@@ -29,9 +29,12 @@ service WLU {
 
 // Top-level message sent by the client for the `Texts` method.
 message TextsRequest {
+  // The target application for the texts request.
+  // Required.
+  string app_id = 1;
   // List of WLURequest.
   // Required.
-  repeated WLURequest requests = 1;
+  repeated WLURequest requests = 2;
 }
 
 // Top-level message sent by the server for the `Texts` method.


### PR DESCRIPTION
The `app_id` is needed when calling the service with an API key.