### PR TITLE
Add notice if the model can be used in streaming transcode or not

### DIFF
--- a/proto/speechly/config/v1/model.proto
+++ b/proto/speechly/config/v1/model.proto
@@ -18,4 +18,6 @@ message BaseModel {
   string alias = 2;
   // Does the model allow downloading on-device model bundles
   bool is_downloadable = 3;
+  // Can the model be used in streaming applications
+  bool is_streamable = 4;
 }


### PR DESCRIPTION
Some base models provide capability for streaming the audio in while streaming transcription out. This flag tells if a specific variant will allow streaming or not.