### PR TITLE
Add supported language code in BaseModel

### DIFF
--- a/proto/speechly/config/v1/model.proto
+++ b/proto/speechly/config/v1/model.proto
@@ -20,4 +20,6 @@ message BaseModel {
   bool is_downloadable = 3;
   // Can the model be used in streaming applications
   bool is_streamable = 4;
+  // What language the model supports
+  string language = 5;
 }


### PR DESCRIPTION
Add the base model language code into returned data to make it easy to manage returned BaseModel lists.