### PR TITLE
Fix markdown formatting

### DIFF
--- a/docs/slu/speechly.slu.v1.md
+++ b/docs/slu/speechly.slu.v1.md
@@ -97,12 +97,12 @@ Option to change the default behaviour of the SLU.
 Describes an SLU entity.
 
 An entity is a specific object in the phrase that falls into some kind of category,
-e.g. in a SAL example "*book book a [burger restaurant](restaurant_type) for [tomorrow](date)"
+e.g. in a SAL example `*book book a [burger restaurant](restaurant_type) for [tomorrow](date)`
 "burger restaurant" would be an entity of type `restaurant_type`,
 and "tomorrow" would be an entity of type `date`.
 
 An entity has a start and end indices which map to the indices of words in SLUTranscript messages,
-e.g. in the example "book a [burger restaurant](restaurant_type) for [tomorrow](date)" it would be:
+e.g. in the example `*book book a [burger restaurant](restaurant_type) for [tomorrow](date)` it would be:
 
 - Entity "burger restaurant" - `start_position = 2, end_position = 3`
 - Entity "tomorrow" - `start_position = 5, end_position = 5`

--- a/docs/wlu/speechly.slu.v1.md
+++ b/docs/wlu/speechly.slu.v1.md
@@ -59,12 +59,12 @@ Top-level message sent by the server for the `Texts` method.
 Describes a single entity in a segment.
 
 An entity is a specific object in the phrase that falls into some kind of category,
-e.g. in a SAL example "*book book a [burger restaurant](restaurant_type) for [tomorrow](date)"
+e.g. in a SAL example `*book book a [burger restaurant](restaurant_type) for [tomorrow](date)`
 "burger restaurant" would be an entity of type `restaurant_type`,
 and "tomorrow" would be an entity of type `date`.
 
 An entity has a start and end indices which map to the indices of words in WLUToken messages,
-e.g. in the example "book a [burger restaurant](restaurant_type) for [tomorrow](date)" it would be:
+e.g. in the example `*book book a [burger restaurant](restaurant_type) for [tomorrow](date)` it would be:
 
 - Entity "burger restaurant" - `start_position = 2, end_position = 3`
 - Entity "tomorrow" - `start_position = 5, end_position = 5`

--- a/proto/speechly/slu/v1/slu.proto
+++ b/proto/speechly/slu/v1/slu.proto
@@ -203,12 +203,12 @@ message SLUTranscript {
 // Describes an SLU entity.
 //
 // An entity is a specific object in the phrase that falls into some kind of category,
-// e.g. in a SAL example "*book book a [burger restaurant](restaurant_type) for [tomorrow](date)"
+// e.g. in a SAL example `*book book a [burger restaurant](restaurant_type) for [tomorrow](date)`
 // "burger restaurant" would be an entity of type `restaurant_type`,
 // and "tomorrow" would be an entity of type `date`.
 //
 // An entity has a start and end indices which map to the indices of words in SLUTranscript messages,
-// e.g. in the example "book a [burger restaurant](restaurant_type) for [tomorrow](date)" it would be:
+// e.g. in the example `*book book a [burger restaurant](restaurant_type) for [tomorrow](date)` it would be:
 //
 // - Entity "burger restaurant" - `start_position = 2, end_position = 3`
 // - Entity "tomorrow" - `start_position = 5, end_position = 5`

--- a/proto/speechly/slu/v1/wlu.proto
+++ b/proto/speechly/slu/v1/wlu.proto
@@ -93,12 +93,12 @@ message WLUToken {
 // Describes a single entity in a segment.
 //
 // An entity is a specific object in the phrase that falls into some kind of category,
-// e.g. in a SAL example "*book book a [burger restaurant](restaurant_type) for [tomorrow](date)"
+// e.g. in a SAL example `*book book a [burger restaurant](restaurant_type) for [tomorrow](date)`
 // "burger restaurant" would be an entity of type `restaurant_type`,
 // and "tomorrow" would be an entity of type `date`.
 //
 // An entity has a start and end indices which map to the indices of words in WLUToken messages,
-// e.g. in the example "book a [burger restaurant](restaurant_type) for [tomorrow](date)" it would be:
+// e.g. in the example `*book book a [burger restaurant](restaurant_type) for [tomorrow](date)` it would be:
 //
 // - Entity "burger restaurant" - `start_position = 2, end_position = 3`
 // - Entity "tomorrow" - `start_position = 5, end_position = 5`


### PR DESCRIPTION
Some examples were using incorrect markdown (but correct sal) that would result in either wrongful markdown or in case of the docs, build errors due to link validation failing.