### PR TITLE
Add priority field to batch_api config message

### DIFF
--- a/proto/speechly/slu/v2/batch.proto
+++ b/proto/speechly/slu/v2/batch.proto
@@ -53,6 +53,11 @@ message BatchConfig {
   // the source system.
   // Optional.
   string batch_reference = 4;
+  // Priority for the operation. Operations are processed in the order they are
+  // created, but higher priority operations are processed before the lower
+  // priority operations.
+  // Optional, defaults to 0 (normal priority).
+  int32 priority = 6;
   // Additional batch specific options.
   // Optional.
   repeated Option options = 5;


### PR DESCRIPTION
The processing order for batch operations can be changed by setting the operation priority to a higher value than 0 (the default). Higher priorities will be processed first from the queue.